### PR TITLE
fix(tests): increase test timeouts to prevent intermittent CI failures

### DIFF
--- a/Tests/SundialKitConnectivityTests/ConnectivityManagerActivationTests.swift
+++ b/Tests/SundialKitConnectivityTests/ConnectivityManagerActivationTests.swift
@@ -24,7 +24,7 @@
       #expect(mockSession.activationState == .activated)
 
       // Wait for delegate callback to propagate through async layers
-      try await Task.sleep(forMilliseconds: 200)  // 0.2 seconds
+      try await Task.sleep(forMilliseconds: 500)  // 0.5 seconds
       #expect(await manager.activationState == .activated)
     }
 
@@ -37,7 +37,7 @@
       #expect(mockSession.activationState == .activated)
 
       // Wait for actor state to be updated
-      try await Task.sleep(forMilliseconds: 200)  // 0.2 seconds
+      try await Task.sleep(forMilliseconds: 500)  // 0.5 seconds
       #expect(await manager.activationState == .activated)
     }
 
@@ -64,7 +64,7 @@
       }
 
       // Give first task time to start
-      try await Task.sleep(forMilliseconds: 200)  // 0.2 seconds
+      try await Task.sleep(forMilliseconds: 500)  // 0.5 seconds
 
       // Try second activation - should throw immediately
       do {

--- a/Tests/SundialKitConnectivityTests/ConnectivityManagerTestHelpers.swift
+++ b/Tests/SundialKitConnectivityTests/ConnectivityManagerTestHelpers.swift
@@ -17,21 +17,33 @@
   ///
   /// - Parameters:
   ///   - timeout: Maximum time to wait in seconds (default: 5)
-  ///   - pollInterval: Time between checks in milliseconds (default: 10ms)
+  ///   - pollInterval: Time between checks in milliseconds (default: 50ms)
   ///   - condition: The condition to check
   /// - Throws: If the timeout expires before the condition becomes true
   internal func waitUntil(
     timeout: TimeInterval = 5,
-    pollInterval: UInt64 = 10,
+    pollInterval: UInt64 = 50,
     _ condition: @escaping () async -> Bool
   ) async throws {
-    let deadline = Date().addingTimeInterval(timeout)
+    let startTime = Date()
+    let deadline = startTime.addingTimeInterval(timeout)
+    var attempts = 0
+
     while Date() < deadline {
+      attempts += 1
       if await condition() {
+        let elapsed = Date().timeIntervalSince(startTime)
+        if elapsed > 1.0 {
+          // Log if it took more than 1 second
+          print("waitUntil: condition met after \(elapsed)s (\(attempts) attempts)")
+        }
         return
       }
       try await Task.sleep(forMilliseconds: pollInterval)
     }
-    Issue.record("Timeout waiting for condition")
+
+    let elapsed = Date().timeIntervalSince(startTime)
+    print("waitUntil: timeout after \(elapsed)s (\(attempts) attempts)")
+    Issue.record("Timeout waiting for condition after \(elapsed)s (\(attempts) attempts)")
   }
 #endif

--- a/Tests/SundialKitCoreTests/ObserverRegistryTests.swift
+++ b/Tests/SundialKitCoreTests/ObserverRegistryTests.swift
@@ -174,7 +174,7 @@ struct ObserverRegistryTests {
     }
 
     // Wait for async notifications to complete
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     #expect(observer1.receivedValues == [42])
     #expect(observer2.receivedValues == [42])
@@ -195,7 +195,7 @@ struct ObserverRegistryTests {
     }
 
     // Wait for async notifications to complete
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     // Both observers should receive the notification (strong references)
     #expect(observer1.receivedValues == [99])

--- a/Tests/SundialKitNetworkTests/NetworkMonitorTests.swift
+++ b/Tests/SundialKitNetworkTests/NetworkMonitorTests.swift
@@ -83,7 +83,7 @@ struct NetworkMonitorTests {
     monitor.start(queue: queue)
 
     // Give it a moment to process
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     #expect(pathMonitor.dispatchQueueLabel == "test.queue")
     #expect(pathMonitor.pathUpdate != nil)
@@ -97,12 +97,12 @@ struct NetworkMonitorTests {
     let monitor = NetworkMonitor(monitor: pathMonitor, ping: nil as NeverPing?)
 
     monitor.start(queue: .global())
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     monitor.stop()
 
     // Wait for async stop to complete
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     #expect(pathMonitor.isCancelled == true)
   }
@@ -113,7 +113,7 @@ struct NetworkMonitorTests {
     let monitor = NetworkMonitor(monitor: pathMonitor, ping: nil as NeverPing?)
 
     monitor.start(queue: .global())
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     // Second start should be ignored
     monitor.start(queue: .global())
@@ -141,7 +141,7 @@ struct NetworkMonitorTests {
     let monitor = NetworkMonitor(monitor: pathMonitor, ping: nil as NeverPing?)
 
     monitor.start(queue: .global())
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     // Send new path update
     let newPath = MockPath(
@@ -151,7 +151,7 @@ struct NetworkMonitorTests {
     )
     pathMonitor.sendPath(newPath)
 
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     #expect(await monitor.pathStatus == .satisfied(.cellular))
     #expect(await monitor.isExpensive == true)
@@ -164,7 +164,7 @@ struct NetworkMonitorTests {
     let monitor = NetworkMonitor(monitor: pathMonitor, ping: nil as NeverPing?)
 
     monitor.start(queue: .global())
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     let newPath = MockPath(
       isConstrained: true,
@@ -173,7 +173,7 @@ struct NetworkMonitorTests {
     )
     pathMonitor.sendPath(newPath)
 
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     #expect(await monitor.isConstrained == true)
   }
@@ -189,7 +189,7 @@ struct NetworkMonitorTests {
     await monitor.addObserver(observer)
     monitor.start(queue: .global())
 
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     // Send update
     let newPath = MockPath(
@@ -199,7 +199,7 @@ struct NetworkMonitorTests {
     )
     pathMonitor.sendPath(newPath)
 
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     #expect(!observer.pathStatusUpdates.isEmpty)
     #expect(observer.pathStatusUpdates.last == .satisfied(.cellular))
@@ -214,7 +214,7 @@ struct NetworkMonitorTests {
     await monitor.addObserver(observer)
     monitor.start(queue: .global())
 
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     let newPath = MockPath(
       isConstrained: false,
@@ -223,7 +223,7 @@ struct NetworkMonitorTests {
     )
     pathMonitor.sendPath(newPath)
 
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     #expect(observer.expensiveUpdates.contains(true))
   }
@@ -237,7 +237,7 @@ struct NetworkMonitorTests {
     await monitor.addObserver(observer)
     monitor.start(queue: .global())
 
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     let newPath = MockPath(
       isConstrained: true,
@@ -246,7 +246,7 @@ struct NetworkMonitorTests {
     )
     pathMonitor.sendPath(newPath)
 
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     #expect(observer.constrainedUpdates.contains(true))
   }
@@ -260,7 +260,7 @@ struct NetworkMonitorTests {
     await monitor.addObserver(observer)
     monitor.start(queue: .global())
 
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     await monitor.removeObservers { ($0 as? TestNetworkStateObserver) === observer }
 
@@ -272,7 +272,7 @@ struct NetworkMonitorTests {
     )
     pathMonitor.sendPath(newPath)
 
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     // Observer should not have received the cellular update
     let hasCellularUpdate = observer.pathStatusUpdates.contains { status in
@@ -294,7 +294,7 @@ struct NetworkMonitorTests {
     await monitor.addObserver(observer)  // Add again (now allowed with strong references)
     monitor.start(queue: .global())
 
-    try await Task.sleep(forMilliseconds: 100)
+    try await Task.sleep(forMilliseconds: 300)
 
     let newPath = MockPath(
       isConstrained: false,
@@ -303,7 +303,7 @@ struct NetworkMonitorTests {
     )
     pathMonitor.sendPath(newPath)
 
-    try await Task.sleep(forMilliseconds: 50)
+    try await Task.sleep(forMilliseconds: 200)
 
     // With strong references, duplicates receive notifications multiple times
     let cellularCount = observer.pathStatusUpdates.filter { status in
@@ -377,7 +377,7 @@ struct NetworkMonitorTests {
     monitor.start(queue: .global())
 
     // Wait for potential ping to execute
-    try await Task.sleep(forMilliseconds: 200)
+    try await Task.sleep(forMilliseconds: 500)
 
     monitor.stop()
 


### PR DESCRIPTION
Increase hardcoded sleep durations and improve waitUntil helper to address intermittent test failures on slow CI runners (exit code 65).

Changes:
- NetworkMonitorTests: 50ms→200ms, 100ms→300ms, 200ms→500ms (13 occurrences)
- ConnectivityManagerActivationTests: 200ms→500ms (3 occurrences)
- ObserverRegistryTests: 50ms→200ms (2 occurrences)
- waitUntil helper: polling 10ms→50ms, added debug logging for timeouts

All 51 tests pass locally with increased timeouts providing better resilience to actor scheduling delays and dispatch queue latency on CI environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/SundialKit/56)
<!-- GitContextEnd -->