### PR TITLE
docs: update version references to alpha releases

### DIFF
--- a/Examples/Sundial/Package.swift
+++ b/Examples/Sundial/Package.swift
@@ -35,17 +35,17 @@ let package = Package(
     // SundialKit core (parent package)
     .package(
       url: "https://github.com/brightdigit/SundialKit.git",
-      branch: "v2.0.0"
+      from: "2.0.0-alpha.1"
     ),
     // SundialKitCombine plugin
     .package(
       url: "https://github.com/brightdigit/SundialKitCombine.git",
-      branch: "v1.0.0"
+      from: "1.0.0-alpha.1"
     ),
     // SundialKitStream plugin
     .package(
       url: "https://github.com/brightdigit/SundialKitStream.git",
-      branch: "v1.0.0"
+      from: "1.0.0-alpha.1"
     )
   ],
   targets: [

--- a/Examples/Sundial/README.md
+++ b/Examples/Sundial/README.md
@@ -1,6 +1,6 @@
 # Sundial Demo Application
 
-A comprehensive iOS/watchOS demonstration of SundialKit v2.0.0 capabilities, with focus on:
+A comprehensive iOS/watchOS demonstration of SundialKit v2.0.0-alpha.1 capabilities, with focus on:
 - **Binary protobuf messaging** with `BinaryMessagable`
 - **Latency measurement** across different transport methods
 - **Transport route comparison** (sendMessage vs updateApplicationContext)

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ let package = Package(
   name: "YourPackage",
   platforms: [.iOS(.v16), .watchOS(.v9), .tvOS(.v16), .macOS(.v13)],
   dependencies: [
-    .package(url: "https://github.com/brightdigit/SundialKit.git", from: "2.0.0"),
-    .package(url: "https://github.com/brightdigit/SundialKitStream.git", from: "1.0.0")
+    .package(url: "https://github.com/brightdigit/SundialKit.git", from: "2.0.0-alpha.1"),
+    .package(url: "https://github.com/brightdigit/SundialKitStream.git", from: "1.0.0-alpha.1")
   ],
   targets: [
     .target(

--- a/Sources/SundialKit/SundialKit.docc/Documentation.md
+++ b/Sources/SundialKit/SundialKit.docc/Documentation.md
@@ -43,7 +43,7 @@ Add SundialKit to your `Package.swift`:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/brightdigit/SundialKit.git", from: "2.0.0")
+  .package(url: "https://github.com/brightdigit/SundialKit.git", from: "2.0.0-alpha.1")
 ]
 ```
 


### PR DESCRIPTION
## Summary

Updates all documentation and demo package dependencies to reference the correct alpha versions:
- **SundialKit**: `2.0.0-alpha.1`
- **SundialKitStream**: `1.0.0-alpha.1`
- **SundialKitCombine**: `1.0.0-alpha.1`

## Changes

- ✅ `README.md`: Update installation examples to use alpha versions
- ✅ `SundialKit.docc/Documentation.md`: Update DocC installation example
- ✅ `Examples/Sundial/Package.swift`: Convert from branch refs to version tags
- ✅ `Examples/Sundial/README.md`: Update version in project description

## Rationale

This ensures users understand they're working with pre-release software and demo builds use stable version references instead of branch heads.

## Notes

⚠️ **Waiting for tags**: This PR is marked as draft until the `1.0.0-alpha.1` tags are created and pushed for SundialKitStream and SundialKitCombine repositories. Once those tags are available, this PR can be marked ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/SundialKit/72)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package dependency version references to alpha releases across documentation and examples for SundialKit, SundialKitCombine, and SundialKitStream packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->