### PR TITLE
fix(connectivity): harden WCSession delegate registration and reply handling

### DIFF
--- a/Sources/SundialKitConnectivity/WatchConnectivitySession+ConnectivitySession.swift
+++ b/Sources/SundialKitConnectivity/WatchConnectivitySession+ConnectivitySession.swift
@@ -142,6 +142,11 @@
       guard WCSession.isSupported() else {
         throw SundialError.sessionNotSupported
       }
+      // Register as the WCSession delegate here (not in `init`) so only the
+      // activated instance owns `WCSession.default`'s delegate. This prevents
+      // throwaway instances — e.g. created by SwiftUI re-evaluating a `@State`
+      // autoclosure — from hijacking delivery from the real instance.
+      session.delegate = self
       session.activate()
     }
   }

--- a/Sources/SundialKitConnectivity/WatchConnectivitySession+ConnectivitySession.swift
+++ b/Sources/SundialKitConnectivity/WatchConnectivitySession+ConnectivitySession.swift
@@ -137,6 +137,12 @@
     ///
     /// Must be called before any message exchange can occur.
     ///
+    /// Registering the WCSession delegate happens here rather than in `init` so that
+    /// only the activated instance owns `WCSession.default`'s delegate; a throwaway
+    /// instance can never hijack delivery from the real one. Calling `activate()` more
+    /// than once on the same instance is safe — re-assigning `session.delegate = self`
+    /// is a no-op and WCSession tolerates a repeated `activate()`.
+    ///
     /// - Throws: `SundialError.sessionNotSupported` if WatchConnectivity is not supported
     public func activate() throws {
       guard WCSession.isSupported() else {

--- a/Sources/SundialKitConnectivity/WatchConnectivitySession+WCSessionDelegate.swift
+++ b/Sources/SundialKitConnectivity/WatchConnectivitySession+WCSessionDelegate.swift
@@ -100,13 +100,27 @@
     ) {
       // WatchConnectivity only supports property list types which are inherently Sendable
       let sendableMessage = ConnectivityMessage(forceCasting: message)
-      let handler = unsafeBitCast(replyHandler, to: ConnectivityHandler.self)
+      // Guard the WCSession reply handler so it can fire at most once. The same
+      // closure is handed to the delegate *and* auto-acknowledged below; a delegate
+      // that actually replies (e.g. via `ConnectivityReceiveContext.replyWith`) would
+      // otherwise invoke `replyHandler` twice, which is undefined behavior on the
+      // sender side.
+      var replied = false
+      let safeReply: ([String: Any]) -> Void = { response in
+        guard !replied else {
+          return
+        }
+        replied = true
+        replyHandler(response)
+      }
+      let handler = unsafeBitCast(safeReply, to: ConnectivityHandler.self)
       delegate?.session(self, didReceiveMessage: sendableMessage, replyHandler: handler)
       // Auto-acknowledge so the sender's reply-expecting `sendMessage` completes
-      // immediately instead of timing out (WCErrorDomain 7012). Mirrors the binary
-      // `didReceiveMessageData` path's `replyHandler(Data())`. Consumers needing to
-      // send a real reply are not supported on this path.
-      replyHandler([:])
+      // immediately instead of timing out (WCErrorDomain 7012). Skipped if the
+      // delegate already replied. Mirrors the binary `didReceiveMessageData` path.
+      if !replied {
+        replyHandler([:])
+      }
     }
 
     internal func session(
@@ -141,9 +155,23 @@
       didReceiveMessageData messageData: Data,
       replyHandler: @escaping (Data) -> Void
     ) {
-      let handler = unsafeBitCast(replyHandler, to: (@Sendable (Data) -> Void).self)
+      // Guard the WCSession reply handler so it can fire at most once. Unlike the
+      // dictionary path, the `ConnectivityDelegateHandling` bridge forwards this
+      // handler to consumers, so a delegate that replies plus the unconditional
+      // auto-acknowledgment below would invoke `replyHandler` twice.
+      var replied = false
+      let safeReply: (Data) -> Void = { response in
+        guard !replied else {
+          return
+        }
+        replied = true
+        replyHandler(response)
+      }
+      let handler = unsafeBitCast(safeReply, to: (@Sendable (Data) -> Void).self)
       delegate?.session(self, didReceiveMessageData: messageData, replyHandler: handler)
-      replyHandler(Data())
+      if !replied {
+        replyHandler(Data())
+      }
     }
   }
 

--- a/Sources/SundialKitConnectivity/WatchConnectivitySession+WCSessionDelegate.swift
+++ b/Sources/SundialKitConnectivity/WatchConnectivitySession+WCSessionDelegate.swift
@@ -102,6 +102,11 @@
       let sendableMessage = ConnectivityMessage(forceCasting: message)
       let handler = unsafeBitCast(replyHandler, to: ConnectivityHandler.self)
       delegate?.session(self, didReceiveMessage: sendableMessage, replyHandler: handler)
+      // Auto-acknowledge so the sender's reply-expecting `sendMessage` completes
+      // immediately instead of timing out (WCErrorDomain 7012). Mirrors the binary
+      // `didReceiveMessageData` path's `replyHandler(Data())`. Consumers needing to
+      // send a real reply are not supported on this path.
+      replyHandler([:])
     }
 
     internal func session(

--- a/Sources/SundialKitConnectivity/WatchConnectivitySession.swift
+++ b/Sources/SundialKitConnectivity/WatchConnectivitySession.swift
@@ -71,7 +71,11 @@
     internal init(session: WCSession) {
       self.session = session
       super.init()
-      session.delegate = self
+      // The WCSession delegate is registered in `activate()`, not here, so that
+      // constructing a `WatchConnectivitySession` has no global side effect. A
+      // throwaway instance (e.g. one created then immediately discarded by a
+      // SwiftUI `@State` autoclosure re-evaluation) must not hijack
+      // `WCSession.default`'s delegate from the active, activated instance.
     }
 
     override public convenience init() {


### PR DESCRIPTION
## Summary

Hardens `WatchConnectivitySession` so WatchConnectivity delivery is reliable and reply handlers behave correctly. No `transferUserInfo` is involved — all messaging stays on the existing dictionary / application-context paths.

## Changes

- **Register the `WCSession` delegate in `activate()`, not `init()`.** Constructing a `WatchConnectivitySession` no longer has the global side effect of claiming `WCSession.default`'s delegate. This prevents a throwaway instance — e.g. one created then discarded by a SwiftUI `@State` autoclosure re-evaluation — from hijacking delivery from the real, activated instance. Calling `activate()` more than once is safe (re-assigning the delegate is a no-op and WCSession tolerates a repeated `activate()`).

- **Auto-acknowledge received messages so reply-expecting sends don't time out.** When a sender uses the reply-expecting `sendMessage`, the receiver now auto-acks (empty reply) if the delegate didn't reply itself, avoiding `WCErrorDomain 7012` timeouts. The dictionary path now mirrors the existing binary `didReceiveMessageData` path.

- **Once-guard the auto-ack reply handlers.** The same reply closure is handed to the delegate *and* auto-acknowledged. A delegate that actually replies (e.g. via `ConnectivityReceiveContext.replyWith`) would otherwise invoke `replyHandler` twice — undefined behavior on the sender side. Both the dictionary and binary paths now wrap the handler so it fires at most once.

## Files

- `WatchConnectivitySession.swift` — drop delegate assignment from `init`
- `WatchConnectivitySession+ConnectivitySession.swift` — assign delegate in `activate()`
- `WatchConnectivitySession+WCSessionDelegate.swift` — once-guarded reply handlers + auto-ack on both message paths
