### PR TITLE
ci: revert swift-coverage-action to sersoft-gmbh@v5

### DIFF
--- a/.github/workflows/SundialKit.yml
+++ b/.github/workflows/SundialKit.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           apt-get update -q
           apt-get install -y curl
-      - uses: brightdigit/swift-coverage-action@fix/swift-6.4-linux-layout
+      - uses: sersoft-gmbh/swift-coverage-action@v5
         id: coverage-files
         if: steps.build.outputs.contains-code-coverage == 'true'
         with:
@@ -214,7 +214,7 @@ jobs:
       # Common Coverage Steps
       - name: Process Coverage
         if: steps.build.outputs.contains-code-coverage == 'true'
-        uses: brightdigit/swift-coverage-action@fix/swift-6.4-linux-layout
+        uses: sersoft-gmbh/swift-coverage-action@v5
 
       - name: Upload Coverage
         if: steps.build.outputs.contains-code-coverage == 'true'
@@ -294,7 +294,7 @@ jobs:
       # Common Coverage Steps
       - name: Process Coverage
         if: steps.build.outputs.contains-code-coverage == 'true'
-        uses: brightdigit/swift-coverage-action@fix/swift-6.4-linux-layout
+        uses: sersoft-gmbh/swift-coverage-action@v5
 
       - name: Upload Coverage
         if: steps.build.outputs.contains-code-coverage == 'true'


### PR DESCRIPTION
The Swift 6.4 Linux layout fix is now released upstream in `sersoft-gmbh/swift-coverage-action@v5`, so this reverts the temporary CI pin to the `brightdigit/swift-coverage-action@fix/swift-6.4-linux-layout` fork branch back to the upstream action (matching `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)